### PR TITLE
Remove commented code from LSP configuration files

### DIFF
--- a/lua/carlosvillu/plugins/lsp/lspconfig.lua
+++ b/lua/carlosvillu/plugins/lsp/lspconfig.lua
@@ -78,59 +78,5 @@ return {
 			vim.fn.sign_define(hl, { text = icon, texthl = hl, numhl = "" })
 		end
 
-		-- mason_lspconfig.setup_handlers({
-		--   -- default handler for installed servers
-		--   function(server_name)
-		--     lspconfig[server_name].setup({
-		--       capabilities = capabilities,
-		--     })
-		--   end,
-		--   ["svelte"] = function()
-		--     -- configure svelte server
-		--     lspconfig["svelte"].setup({
-		--       capabilities = capabilities,
-		--       on_attach = function(client, bufnr)
-		--         vim.api.nvim_create_autocmd("BufWritePost", {
-		--           pattern = { "*.js", "*.ts" },
-		--           callback = function(ctx)
-		--             -- Here use ctx.match instead of ctx.file
-		--             client.notify("$/onDidChangeTsOrJsFile", { uri = ctx.match })
-		--           end,
-		--         })
-		--       end,
-		--     })
-		--   end,
-		--   ["graphql"] = function()
-		--     -- configure graphql language server
-		--     lspconfig["graphql"].setup({
-		--       capabilities = capabilities,
-		--       filetypes = { "graphql", "gql", "svelte", "typescriptreact", "javascriptreact" },
-		--     })
-		--   end,
-		--   ["emmet_ls"] = function()
-		--     -- configure emmet language server
-		--     lspconfig["emmet_ls"].setup({
-		--       capabilities = capabilities,
-		--       filetypes = { "html", "typescriptreact", "javascriptreact", "css", "sass", "scss", "less", "svelte" },
-		--     })
-		--   end,
-		--   ["lua_ls"] = function()
-		--     -- configure lua server (with special settings)
-		--     lspconfig["lua_ls"].setup({
-		--       capabilities = capabilities,
-		--       settings = {
-		--         Lua = {
-		--           -- make the language server recognize "vim" global
-		--           diagnostics = {
-		--             globals = { "vim" },
-		--           },
-		--           completion = {
-		--             callSnippet = "Replace",
-		--           },
-		--         },
-		--       },
-		--     })
-		--   end,
-		-- })
 	end,
 }

--- a/lua/carlosvillu/plugins/lsp/mason.lua
+++ b/lua/carlosvillu/plugins/lsp/mason.lua
@@ -27,7 +27,6 @@ return {
 		mason_lspconfig.setup({
 			-- list of servers for mason to install
 			ensure_installed = {
-				-- "tsserver",
 				"html",
 				"cssls",
 				"tailwindcss",


### PR DESCRIPTION
## Summary
• Remove large commented mason_lspconfig.setup_handlers block from lspconfig.lua (lines 81-134)
• Remove commented tsserver entry from mason.lua

## Test plan
- [ ] Verify Neovim configuration still loads without errors
- [ ] Test LSP functionality remains intact
- [ ] Confirm Mason LSP installations work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)